### PR TITLE
Expand simulator with global impact view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # EconomicPolicySimulator
-A simulator to determine the economic returns and the efficacy of social, fiscal and monetary policy.
+
+A simple Python simulator to estimate the economic returns of social, fiscal and monetary policies.
+
+## Features
+- Basic model of GDP growth influenced by interest rates, government spending and taxes.
+- Command line interface for running simulations over multiple years.
+- Interactive map showing projected GDP for each U.S. state with a menu to adjust policies. The menu also includes an option to view the global impact of current settings.
+
+## Usage
+
+Install dependencies (plotly is required for the map interface) and run the CLI:
+
+```bash
+pip install plotly
+python -m econ_simulator.cli 1000 --interest-rate 0.05 --gov-spending 0.2 --tax-rate 0.2 --years 3
+```
+
+This command simulates an economy starting with a GDP of 1000 units for three years.
+
+### Map Interface
+
+Launch the interactive map with:
+
+```bash
+python -m econ_simulator.gui --interest-rate 0.05 --gov-spending 0.2 --tax-rate 0.2 --years 1
+```
+
+A map of the United States will open in your browser. Hover over any state to see its projected GDP. Use the on-screen menu in the terminal to change policy parameters and refresh the map. You can also select the global impact option to view projected GDP for several major economies.

--- a/econ_simulator/cli.py
+++ b/econ_simulator/cli.py
@@ -1,0 +1,34 @@
+"""Command-line interface for the economic policy simulator."""
+
+import argparse
+from .simulation import PolicyInputs, simulate_economy
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a simple economic policy simulation")
+    parser.add_argument("initial_gdp", type=float, help="Initial GDP value")
+    parser.add_argument("--interest-rate", type=float, default=0.05, help="Interest rate (as decimal)")
+    parser.add_argument(
+        "--gov-spending", type=float, default=0.2, help="Government spending as percentage of GDP"
+    )
+    parser.add_argument("--tax-rate", type=float, default=0.2, help="Tax rate as percentage of GDP")
+    parser.add_argument("--years", type=int, default=1, help="Number of years to simulate")
+    args = parser.parse_args()
+
+    policies = PolicyInputs(
+        interest_rate=args.interest_rate,
+        government_spending_pct=args.gov_spending,
+        tax_rate=args.tax_rate,
+    )
+
+    result = simulate_economy(args.initial_gdp, policies, years=args.years)
+
+    for year, gdp in enumerate(result.gdp_history):
+        if year == 0:
+            print(f"Year {year}: starting GDP = {gdp:.2f}")
+        else:
+            print(f"Year {year}: predicted GDP = {gdp:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/econ_simulator/global_simulation.py
+++ b/econ_simulator/global_simulation.py
@@ -1,0 +1,23 @@
+"""Simulation utilities for global policy impact."""
+
+from typing import Dict
+
+from .simulation import PolicyInputs, simulate_economy
+
+# Baseline GDP values for a few major economies (in billions of dollars)
+GLOBAL_BASE_GDP = {
+    "USA": 21000,
+    "CHN": 14000,
+    "DEU": 3800,
+    "IND": 2900,
+    "BRA": 1800,
+}
+
+
+def simulate_global(policies: PolicyInputs, years: int = 1) -> Dict[str, float]:
+    """Simulate GDP outcomes for several major economies."""
+    results: Dict[str, float] = {}
+    for code, gdp in GLOBAL_BASE_GDP.items():
+        result = simulate_economy(gdp, policies, years=years)
+        results[code] = result.gdp_history[-1]
+    return results

--- a/econ_simulator/gui.py
+++ b/econ_simulator/gui.py
@@ -1,0 +1,85 @@
+"""Interactive map-based interface for the economic simulator."""
+
+import argparse
+from typing import Dict
+
+import plotly.express as px
+
+from .simulation import PolicyInputs
+from .state_simulation import simulate_states
+from .global_simulation import simulate_global
+
+
+def show_map(state_gdp: Dict[str, float]) -> None:
+    """Display an interactive map of the U.S. with GDP data."""
+    fig = px.choropleth(
+        locations=list(state_gdp.keys()),
+        locationmode="USA-states",
+        color=list(state_gdp.values()),
+        scope="usa",
+        color_continuous_scale="Blues",
+        labels={"color": "GDP"},
+    )
+    fig.update_layout(title_text="Projected GDP by State")
+    fig.show()
+
+
+def show_global_map(global_gdp: Dict[str, float]) -> None:
+    """Display a simple world map showing GDP results."""
+    fig = px.choropleth(
+        locations=list(global_gdp.keys()),
+        locationmode="ISO-3",
+        color=list(global_gdp.values()),
+        scope="world",
+        color_continuous_scale="Greens",
+        labels={"color": "GDP"},
+    )
+    fig.update_layout(title_text="Projected Global GDP Impact")
+    fig.show()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Interactive US map for policy simulation")
+    parser.add_argument("--interest-rate", type=float, default=0.05, help="Interest rate")
+    parser.add_argument("--gov-spending", type=float, default=0.2, help="Government spending as pct of GDP")
+    parser.add_argument("--tax-rate", type=float, default=0.2, help="Tax rate as pct of GDP")
+    parser.add_argument("--years", type=int, default=1, help="Number of years to simulate")
+    args = parser.parse_args()
+
+    policies = PolicyInputs(
+        interest_rate=args.interest_rate,
+        government_spending_pct=args.gov_spending,
+        tax_rate=args.tax_rate,
+    )
+
+    while True:
+        state_gdp = simulate_states(policies, years=args.years)
+        show_map(state_gdp)
+        print("\nCurrent policy settings:")
+        print(f"  Interest rate: {policies.interest_rate}")
+        print(f"  Government spending (% GDP): {policies.government_spending_pct}")
+        print(f"  Tax rate (% GDP): {policies.tax_rate}")
+        print("\nMenu:")
+        print("  1. Change interest rate")
+        print("  2. Change government spending")
+        print("  3. Change tax rate")
+        print("  4. View global impact")
+        print("  5. Quit")
+        choice = input("Select an option: ")
+        if choice == "1":
+            policies.interest_rate = float(input("Enter new interest rate: "))
+        elif choice == "2":
+            policies.government_spending_pct = float(input("Enter new government spending (% GDP): "))
+        elif choice == "3":
+            policies.tax_rate = float(input("Enter new tax rate (% GDP): "))
+        elif choice == "4":
+            global_gdp = simulate_global(policies, years=args.years)
+            show_global_map(global_gdp)
+        elif choice == "5":
+            break
+        else:
+            print("Invalid choice. Please try again.")
+
+
+if __name__ == "__main__":
+    main()

--- a/econ_simulator/simulation.py
+++ b/econ_simulator/simulation.py
@@ -1,0 +1,47 @@
+"""Simple economic simulation model."""
+
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class PolicyInputs:
+    interest_rate: float
+    government_spending_pct: float  # percentage of GDP
+    tax_rate: float  # percentage of GDP
+
+@dataclass
+class SimulationResult:
+    gdp_history: List[float]
+
+BASE_GROWTH = 0.02
+SPENDING_MULTIPLIER = 0.5
+TAX_MULTIPLIER = 0.4
+INTEREST_RATE_MULTIPLIER = 0.3
+
+def simulate_economy(
+    initial_gdp: float,
+    policies: PolicyInputs,
+    years: int = 1,
+) -> SimulationResult:
+    """Run a simple economic simulation.
+
+    Args:
+        initial_gdp: Starting GDP value.
+        policies: Policy inputs for the simulation.
+        years: Number of years to simulate.
+
+    Returns:
+        SimulationResult containing GDP values for each year.
+    """
+    gdp = initial_gdp
+    history = [gdp]
+    for _ in range(years):
+        growth_rate = (
+            BASE_GROWTH
+            + SPENDING_MULTIPLIER * policies.government_spending_pct
+            - TAX_MULTIPLIER * policies.tax_rate
+            - INTEREST_RATE_MULTIPLIER * policies.interest_rate
+        )
+        gdp *= 1 + growth_rate
+        history.append(gdp)
+    return SimulationResult(gdp_history=history)

--- a/econ_simulator/state_simulation.py
+++ b/econ_simulator/state_simulation.py
@@ -1,0 +1,23 @@
+"""Utilities for running simulations across U.S. states."""
+
+from typing import Dict
+
+from .simulation import PolicyInputs, simulate_economy
+from .us_states import STATE_BASE_GDP
+
+
+def simulate_states(policies: PolicyInputs, years: int = 1) -> Dict[str, float]:
+    """Run the economic simulation for each U.S. state.
+
+    Args:
+        policies: Policy inputs shared by all states.
+        years: Number of years to simulate.
+
+    Returns:
+        Mapping of state abbreviation to predicted GDP after the final year.
+    """
+    results: Dict[str, float] = {}
+    for abbr, gdp in STATE_BASE_GDP.items():
+        result = simulate_economy(gdp, policies, years=years)
+        results[abbr] = result.gdp_history[-1]
+    return results

--- a/econ_simulator/us_states.py
+++ b/econ_simulator/us_states.py
@@ -1,0 +1,9 @@
+STATE_ABBREVIATIONS = [
+    "AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
+    "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD",
+    "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV", "NH", "NJ",
+    "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC",
+    "SD", "TN", "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY",
+]
+
+STATE_BASE_GDP = {abbr: 1000 + i * 20 for i, abbr in enumerate(STATE_ABBREVIATIONS)}

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from econ_simulator.simulation import PolicyInputs, simulate_economy
+
+
+def test_simulation_basic():
+    policies = PolicyInputs(interest_rate=0.05, government_spending_pct=0.2, tax_rate=0.2)
+    result = simulate_economy(1000, policies, years=1)
+    assert len(result.gdp_history) == 2
+    assert result.gdp_history[0] == 1000
+    assert result.gdp_history[1] > 0
+from econ_simulator.state_simulation import simulate_states
+from econ_simulator.us_states import STATE_ABBREVIATIONS
+from econ_simulator.global_simulation import simulate_global, GLOBAL_BASE_GDP
+
+
+def test_simulate_states_returns_all_states():
+    policies = PolicyInputs(interest_rate=0.05, government_spending_pct=0.2, tax_rate=0.2)
+    state_results = simulate_states(policies, years=1)
+    assert set(state_results.keys()) == set(STATE_ABBREVIATIONS)
+    for value in state_results.values():
+        assert value > 0
+
+
+def test_simulate_global_returns_all_regions():
+    policies = PolicyInputs(interest_rate=0.05, government_spending_pct=0.2, tax_rate=0.2)
+    global_results = simulate_global(policies, years=1)
+    assert set(global_results.keys()) == set(GLOBAL_BASE_GDP.keys())
+    for value in global_results.values():
+        assert value > 0


### PR DESCRIPTION
## Summary
- add global simulation utilities for a handful of major economies
- extend the interactive GUI with a "View global impact" menu option
- document the global impact tab in the README
- test global simulation logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685822467918832dafa69935b312ef66